### PR TITLE
fix imagenet example and simplify init

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,9 @@ There are some more necessary steps that don't work with the OF project generato
 
 ### OSX
 
-An OSX version is on the way and will be updated here..
+First make sure to install [CUDA 8.0 64bit](https://developer.nvidia.com/cuda-downloads) (Driver & Toolkit). CUDA requires an NVIDIA graphics card and a reasonably recent Mac OS.
+
+After that, projects should compile fine from the Project Generator. Make sure to download the necessary weights (links can be found [here](http://pjreddie.com/darknet/yolo/) and include the required cfg files (found in the examples) in any app that opens them.
 
 ## Training your own models
 

--- a/example-deepdream/src/ofApp.cpp
+++ b/example-deepdream/src/ofApp.cpp
@@ -17,7 +17,7 @@ void ofApp::setup()
 	int octaves = 4;
 	float rate = 0.01;
 	float thresh = 1.0;
-	nightmare = darknet.nightmate( dog.getPixelsRef(), max_layer, range, norm, rounds, iters, octaves, rate, thresh );
+	nightmare = darknet.nightmare( dog.getPixels(), max_layer, range, norm, rounds, iters, octaves, rate, thresh );
 }
 
 void ofApp::update()

--- a/example-imagenet/src/ofApp.cpp
+++ b/example-imagenet/src/ofApp.cpp
@@ -2,11 +2,11 @@
 
 void ofApp::setup() 
 {
-	std::string datacfg = ofToDataPath( "cfg/imagenet1k.data" );
 	std::string cfgfile = ofToDataPath( "cfg/darknet.cfg" );
 	std::string weightfile = ofToDataPath( "darknet.weights" );
 	std::string nameslist = ofToDataPath( "cfg/imagenet.shortnames.list" );
-	darknet.init( cfgfile, weightfile, datacfg, nameslist );
+
+    darknet.init( cfgfile, weightfile, nameslist );
 
 	video.setDeviceID( 0 );
 	video.setDesiredFrameRate( 30 );
@@ -24,7 +24,7 @@ void ofApp::draw()
 	video.draw( 0, 0 );
 
 	if( video.isFrameNew() ) {
-		classifications = darknet.classify( video.getPixelsRef() );
+		classifications = darknet.classify( video.getPixels() );
 	}
 	
 	int offset = 20;

--- a/example-rnn/src/ofApp.cpp
+++ b/example-rnn/src/ofApp.cpp
@@ -2,7 +2,7 @@
 
 void ofApp::setup() 
 {
-	std::string cfgfile = ofToDataPath( "cfg/cfg/rnn.cfg" );
+	std::string cfgfile = ofToDataPath( "cfg/rnn.cfg" );
 	std::string weightfile = ofToDataPath( "arts_arthistory_aesthetics.weights" );
 	darknet.init( cfgfile, weightfile );
 }

--- a/example-yolo2/bin/data/cfg/yolo9000.cfg
+++ b/example-yolo2/bin/data/cfg/yolo9000.cfg
@@ -207,5 +207,5 @@ thresh = .6
 absolute=1
 random=1
 
-tree=data/cfg/9k.tree
-map=data/cfg/coco9k.map
+tree=../../../data/cfg/9k.tree
+map=../../../data/cfg/coco9k.map

--- a/example-yolo2/bin/data/cfg/yolo9000.cfg
+++ b/example-yolo2/bin/data/cfg/yolo9000.cfg
@@ -207,5 +207,5 @@ thresh = .6
 absolute=1
 random=1
 
-tree=../../../data/cfg/9k.tree
-map=../../../data/cfg/coco9k.map
+tree=data/cfg/9k.tree
+map=data/cfg/coco9k.map

--- a/example-yolo2/src/ofApp.cpp
+++ b/example-yolo2/src/ofApp.cpp
@@ -2,10 +2,11 @@
 
 void ofApp::setup() 
 {
-	std::string datacfg = ofToDataPath( "cfg/combine9k.data" );
 	std::string cfgfile = ofToDataPath( "cfg/yolo9000.cfg" );
 	std::string weightfile = ofToDataPath( "yolo9000.weights" );
-	darknet.init( cfgfile, weightfile, datacfg );
+	std::string namesfile = ofToDataPath( "cfg/9k.names" );
+    
+	darknet.init( cfgfile, weightfile, namesfile );
 
 	video.setDeviceID( 0 );
 	video.setDesiredFrameRate( 30 );
@@ -25,7 +26,7 @@ void ofApp::draw()
 	video.draw( 0, 0 );
 
 	if( video.isFrameNew() ) {
-		std::vector< detected_object > detections = darknet.yolo( video.getPixelsRef(), thresh );
+		std::vector< detected_object > detections = darknet.yolo( video.getPixels(), thresh );
 
 		ofNoFill();	
 		for( detected_object d : detections )

--- a/libs/darknet/include/parser.c
+++ b/libs/darknet/include/parser.c
@@ -32,6 +32,7 @@
 #include "softmax_layer.h"
 #include "utils.h"
 
+
 typedef struct{
     char *type;
     list1 *options;
@@ -263,9 +264,30 @@ layer parse_region(list1 *options, size_params params)
     l.bias_match = option_find_int_quiet(options, "bias_match",0);
 
     char *tree_file = option_find_str(options, "tree", 0);
-    if (tree_file) l.softmax_tree = read_tree(tree_file);
+	if( tree_file ) { 
+
+#ifdef _WIN32
+		l.softmax_tree = read_tree( tree_file );
+#else
+		char * buffer = malloc( strlen( "../../../" ) + strlen( tree_file ) + 1 );
+		strcpy( buffer, "../../../" );
+		strcat( buffer, tree_file );
+		l.softmax_tree = read_tree( buffer );
+#endif
+		
+	}
     char *map_file = option_find_str(options, "map", 0);
-    if (map_file) l.map = read_map(map_file);
+	if( map_file ) {
+#ifdef _WIN32
+		l.map = read_map( map_file );
+#else
+		char * buffer = malloc( strlen( "../../../" ) + strlen( map_file ) + 1 );
+		strcpy( buffer, "../../../" );
+		strcat( buffer, map_file );
+		l.map = read_map( buffer );
+#endif
+		
+	}
 
     char *a = option_find_str(options, "anchors", 0);
     if(a){

--- a/src/ofxDarknet.cpp
+++ b/src/ofxDarknet.cpp
@@ -102,11 +102,12 @@ std::vector< classification > ofxDarknet::classify( ofPixels & pix, int count )
 {
 	int *indexes = ( int* ) calloc( count, sizeof( int ) );
 
-	if( pix.getWidth() != net.w && pix.getHeight() != net.h ) {
-		pix.resize( net.w, net.h );
+    ofPixels  pix2( pix );
+	if( pix2.getWidth() != net.w && pix2.getHeight() != net.h ) {
+		pix2.resize( net.w, net.h );
 	}
 
-	image im = convert( pix );
+	image im = convert( pix2 );
 
 	float *predictions = network_predict( net, im.data1 );
 

--- a/src/ofxDarknet.cpp
+++ b/src/ofxDarknet.cpp
@@ -8,21 +8,15 @@ ofxDarknet::~ofxDarknet()
 {
 }
 
-void ofxDarknet::init( std::string cfgfile, std::string weightfile, std::string datacfg, std::string nameslist )
+void ofxDarknet::init( std::string cfgfile, std::string weightfile, std::string nameslist )
 {
     cuda_set_device(0);
 	net = parse_network_cfg( cfgfile.c_str() );
 	load_weights( &net, weightfile.c_str() );
 	set_batch_network( &net, 1 );
-
-	if( !datacfg.empty() )
-	{
-		options1 = read_data_cfg((char *) datacfg.c_str() );
-	}
-	//if( !nameslist.empty() )
-	{
-		names = get_labels( option_find_str( options1, "names", nameslist.c_str() ) );
-	}
+    if (!nameslist.empty()){
+        names = get_labels( (char *) nameslist.c_str() );
+    }
 }
 
 std::vector< detected_object > ofxDarknet::yolo( ofPixels & pix, float threshold /*= 0.24f */ )
@@ -86,7 +80,7 @@ std::vector< detected_object > ofxDarknet::yolo( ofPixels & pix, float threshold
 	return detections;
 }
 
-ofImage ofxDarknet::nightmate( ofPixels & pix, int max_layer, int range, int norm, int rounds, int iters, int octaves, float rate, float thresh )
+ofImage ofxDarknet::nightmare( ofPixels & pix, int max_layer, int range, int norm, int rounds, int iters, int octaves, float rate, float thresh )
 {
 	image im = convert( pix );
 

--- a/src/ofxDarknet.h
+++ b/src/ofxDarknet.h
@@ -61,9 +61,9 @@ public:
 	ofxDarknet();
 	~ofxDarknet();
 
-	void init( std::string cfgfile, std::string weightfile, std::string datacfg = "", std::string nameslist = "" );
+	void init( std::string cfgfile, std::string weightfile, std::string nameslist = "");
 	std::vector< detected_object > yolo( ofPixels & pix, float threshold = 0.24f );
-	ofImage nightmate( ofPixels & pix, int max_layer, int range, int norm, int rounds, int iters, int octaves, float rate, float thresh );
+	ofImage nightmare( ofPixels & pix, int max_layer, int range, int norm, int rounds, int iters, int octaves, float rate, float thresh );
 	std::vector< classification > classify( ofPixels & pix, int count = 5 );
 	std::string rnn( int num, std::string seed, float temp );
 


### PR DESCRIPTION
two changes bundled here:

1) change init process to remove the redundant .data files, refer to .names file directly. this resolves path issues in osx and i think doesn't affect windows (but check first).

2) fix bug in classify method, fixing imagenet example.