### PR TITLE
Fix wrong name in get_network_output_layer_gpu

### DIFF
--- a/libs/darknet/include/network.h
+++ b/libs/darknet/include/network.h
@@ -80,7 +80,7 @@ extern "C" {
 	void sync_nets( network *nets, int n, int interval );
 	float train_network_datum_gpu( network net, float *x, float *y );
 	float *network_predict_gpu( network net, float *input );
-	float * get_network_output_gpu_layer( network net, int i );
+	float * get_network_output_layer_gpu( network net, int i );
 	float * get_network_delta_gpu_layer( network net, int i );
 	float *get_network_output_gpu( network net );
 	void forward_network_gpu( network net, network_state state );

--- a/libs/darknet/include/network_kernels.cu
+++ b/libs/darknet/include/network_kernels.cu
@@ -36,7 +36,7 @@
 #include "blas.h"
 
 
-float * get_network_output_gpu_layer(network net, int i);
+float * get_network_output_layer_gpu(network net, int i);
 float * get_network_delta_gpu_layer(network net, int i);
 float * get_network_output_gpu(network net);
 
@@ -405,4 +405,3 @@ float *network_predict_gpu(network net, float *input)
     cuda_free(state.input);
     return out;
 }
-


### PR DESCRIPTION
The function declared incorrectly, resulting in a linking error if you tried to use it. This is the correct name in the .cu file