### PR TITLE
feature detection + memory leak fix

### DIFF
--- a/example-yolo2/src/ofApp.cpp
+++ b/example-yolo2/src/ofApp.cpp
@@ -41,6 +41,10 @@ void ofApp::draw()
 			ofNoFill();
 			ofDrawRectangle( d.rect );
 			ofDrawBitmapStringHighlight( d.label + ": " + ofToString(d.probability), d.rect.x, d.rect.y + 20 );
+            
+            // optionally, you can grab the 1024-length feature vector associated
+            // with each detected object
+            vector<float> & features = d.features;
 		}
 	}
 }

--- a/example-yolo2/src/ofApp.cpp
+++ b/example-yolo2/src/ofApp.cpp
@@ -20,13 +20,18 @@ void ofApp::update()
 
 void ofApp::draw()
 {
+    // detected objects with confidence < threshold are omitted
 	float thresh = ofMap( ofGetMouseX(), 0, ofGetWidth(), 0, 1 );
-	
+
+    // if a detected object overlaps >maxOverlap with another detected
+    // object with a higher confidence, it gets omitted
+    float maxOverlap = 0.25;
+    
 	ofSetColor( 255 );
 	video.draw( 0, 0 );
 
 	if( video.isFrameNew() ) {
-		std::vector< detected_object > detections = darknet.yolo( video.getPixels(), thresh );
+		std::vector< detected_object > detections = darknet.yolo( video.getPixels(), thresh, maxOverlap );
 
 		ofNoFill();	
 		for( detected_object d : detections )

--- a/src/ofxDarknet.cpp
+++ b/src/ofxDarknet.cpp
@@ -36,7 +36,6 @@ std::vector< detected_object > ofxDarknet::yolo( ofPixels & pix, float threshold
 	network_predict( net, X );
 	get_region_boxes( l, 1, 1, threshold, probs, boxes, 0, 0 );
 	do_nms_sort( boxes, probs, l.w*l.h*l.n, l.classes, 0.4 );
-	//free_image( sized );
 	free_image( im );
 	std::vector< detected_object > detections;
 
@@ -77,6 +76,10 @@ std::vector< detected_object > ofxDarknet::yolo( ofPixels & pix, float threshold
 			detections.push_back( detection );
 		}
 	}
+    
+    free_ptrs((void**) probs, num);
+    free(boxes);
+
 	return detections;
 }
 
@@ -121,6 +124,7 @@ std::vector< classification > ofxDarknet::classify( ofPixels & pix, int count )
 		classifications.push_back( c );
 	}
 	free_image( im );
+    free(indexes);
 	return classifications;
 }
 

--- a/src/ofxDarknet.cpp
+++ b/src/ofxDarknet.cpp
@@ -19,7 +19,7 @@ void ofxDarknet::init( std::string cfgfile, std::string weightfile, std::string 
     }
 }
 
-std::vector< detected_object > ofxDarknet::yolo( ofPixels & pix, float threshold /*= 0.24f */ )
+std::vector< detected_object > ofxDarknet::yolo( ofPixels & pix, float threshold /*= 0.24f */, float maxOverlap /*= 0.5f */ )
 {
 	int originalWidth = pix.getWidth();
 	int originalHeight = pix.getHeight();
@@ -32,50 +32,83 @@ std::vector< detected_object > ofxDarknet::yolo( ofPixels & pix, float threshold
 	float **probs = ( float** ) calloc( l.w*l.h*l.n, sizeof( float * ) );
 	for( int j = 0; j < l.w*l.h*l.n; ++j ) probs[ j ] = ( float* ) calloc( l.classes, sizeof( float * ) );
 
-	float *X = im.data1;
-	network_predict( net, X );
+	network_predict( net, im.data1 );
 	get_region_boxes( l, 1, 1, threshold, probs, boxes, 0, 0 );
 	do_nms_sort( boxes, probs, l.w*l.h*l.n, l.classes, 0.4 );
 	free_image( im );
-	std::vector< detected_object > detections;
 
-	int num = l.w*l.h*l.n;
+    std::vector< detected_object > detections;
+    int num = l.w*l.h*l.n;
+    
+    int feature_layer = net.n - 2;
+    layer l1 = net.layers[ feature_layer ];
+    float * features = get_network_output_layer_gpu(net, feature_layer);
+    
+    vector<size_t> sorted(num);
+    iota(sorted.begin(), sorted.end(), 0);
+    sort(sorted.begin(), sorted.end(), [&probs, &l](int i1, int i2) {
+        return probs[i1][max_index(probs[i1], l.classes)] > probs[i2][max_index(probs[i2], l.classes)];
+    });
+    
 	for( int i = 0; i < num; ++i ) {
-		int class1 = max_index( probs[ i ], l.classes );
-		float prob = probs[ i ][ class1 ];
-		if( prob > threshold ) {
+        int idx = sorted[i];
+		int class1 = max_index( probs[ idx ], l.classes );
+		float prob = probs[ idx ][ class1 ];
 
-			int offset = class1 * 123457 % l.classes;
-			float red = get_color( 2, offset, l.classes );
-			float green = get_color( 1, offset, l.classes );
-			float blue = get_color( 0, offset, l.classes );
+        if( prob < threshold ) {
+            continue;
+        }
 
-			box b = boxes[ i ];
+        int offset = class1 * 123457 % l.classes;
+        float red = get_color( 2, offset, l.classes );
+        float green = get_color( 1, offset, l.classes );
+        float blue = get_color( 0, offset, l.classes );
 
-			int left = ( b.x - b.w / 2. )*im.w;
-			int right = ( b.x + b.w / 2. )*im.w;
-			int top = ( b.y - b.h / 2. )*im.h;
-			int bot = ( b.y + b.h / 2. )*im.h;
+        box b = boxes[ idx ];
 
-			if( left < 0 ) left = 0;
-			if( right > im.w - 1 ) right = im.w - 1;
-			if( top < 0 ) top = 0;
-			if( bot > im.h - 1 ) bot = im.h - 1;
+        int left = ( b.x - b.w / 2. )*im.w;
+        int right = ( b.x + b.w / 2. )*im.w;
+        int top = ( b.y - b.h / 2. )*im.h;
+        int bot = ( b.y + b.h / 2. )*im.h;
 
-			left = ofMap( left, 0, net.w, 0, originalWidth );
-			top = ofMap( top, 0, net.h, 0, originalHeight );
-			right = ofMap( right, 0, net.w, 0, originalWidth );
-			bot = ofMap( bot, 0, net.h, 0, originalHeight );
+        if( left < 0 ) left = 0;
+        if( right > im.w - 1 ) right = im.w - 1;
+        if( top < 0 ) top = 0;
+        if( bot > im.h - 1 ) bot = im.h - 1;
 
-			detected_object detection;
-			detection.label = names[ class1 ];
-			detection.probability = prob;
-			detection.rect = ofRectangle( left, top, right - left, bot - top );
-			detection.color = ofColor( red * 255, green * 255, blue * 255);
+        left = ofMap( left, 0, net.w, 0, originalWidth );
+        top = ofMap( top, 0, net.h, 0, originalHeight );
+        right = ofMap( right, 0, net.w, 0, originalWidth );
+        bot = ofMap( bot, 0, net.h, 0, originalHeight );
 
-			detections.push_back( detection );
-		}
-	}
+        ofRectangle rect = ofRectangle( left, top, right - left, bot - top );
+        int rect_idx = floor(idx / l.n);
+        
+        float overlap = 0.0;
+        for (auto d : detections) {
+            float left = max(rect.x, d.rect.x);
+            float right = min(rect.x+rect.width, d.rect.x+d.rect.width);
+            float bottom = min(rect.y+rect.height, d.rect.y+d.rect.height);
+            float top = max(rect.y, d.rect.y);
+            float area_intersection = max(0.0f, right-left) * max(0.0f, bottom-top);
+            overlap = max(overlap, area_intersection / (rect.getWidth() * rect.getHeight()));
+        }
+        if (overlap > maxOverlap) {
+            continue;
+        }
+
+        detected_object detection;
+        detection.label = names[ class1 ];
+        detection.probability = prob;
+        detection.rect = rect;
+        detection.color = ofColor( red * 255, green * 255, blue * 255);
+
+        for (int f=0; f<l1.c; f++) {
+            detection.features.push_back(features[rect_idx + l1.w * l1.h * f]);
+        }
+        
+        detections.push_back( detection );
+    }
     
     free_ptrs((void**) probs, num);
     free(boxes);

--- a/src/ofxDarknet.h
+++ b/src/ofxDarknet.h
@@ -27,7 +27,6 @@
 #include "region_layer.h"
 #include "normalization_layer.h"
 #include "reorg_layer.h"
-
 #include "cost_layer.h"
 #include "softmax_layer.h"
 #include "route_layer.h"
@@ -47,6 +46,7 @@ struct detected_object {
 	ofRectangle rect;
 	std::string label;
 	float probability;
+    vector<float> features;
 	ofColor color;
 };
 
@@ -62,7 +62,7 @@ public:
 	~ofxDarknet();
 
 	void init( std::string cfgfile, std::string weightfile, std::string nameslist = "");
-	std::vector< detected_object > yolo( ofPixels & pix, float threshold = 0.24f );
+	std::vector< detected_object > yolo( ofPixels & pix, float threshold = 0.24f, float maxOverlap = 0.5f );
 	ofImage nightmare( ofPixels & pix, int max_layer, int range, int norm, int rounds, int iters, int octaves, float rate, float thresh );
 	std::vector< classification > classify( ofPixels & pix, int count = 5 );
 	std::string rnn( int num, std::string seed, float temp );


### PR DESCRIPTION
two things bundled here:

1) simple fix of memory leak in yolo, cleaning up pointers for `boxes` and `probs`. should run more smoothly now.

2) yolo detections now come with feature vectors (length 1024) from the second to last layer of `yolo9000.weights`. these can be used for similarity calculations and all the other stuff.

i don't see any immediate reason why these wouldn't work with windows/linux, but we should check first before pushing it to master.