### PR TITLE
Add native cv::Mat support

### DIFF
--- a/src/ofxDarknet.cpp
+++ b/src/ofxDarknet.cpp
@@ -73,92 +73,115 @@ std::vector< detected_object > ofxDarknet::yolo( ofPixels & pix, float threshold
         pix2.resize( net.w, net.h );
     }
 	image im = convert( pix2 );
-	layer l = net.layers[ net.n - 1 ];
 
-	box *boxes = ( box* ) calloc( l.w*l.h*l.n, sizeof( box ) );
-	float **probs = ( float** ) calloc( l.w*l.h*l.n, sizeof( float * ) );
-	for( int j = 0; j < l.w*l.h*l.n; ++j ) probs[ j ] = ( float* ) calloc( l.classes, sizeof( float * ) );
+	return processImage(im, threshold, maxOverlap, originalWidth, originalHeight);
+	
+}
 
-	network_predict( net, im.data1 );
-	get_region_boxes( l, 1, 1, threshold, probs, boxes, 0, 0 );
-	do_nms_sort( boxes, probs, l.w*l.h*l.n, l.classes, 0.4 );
-	free_image( im );
+#ifdef OPENCV
+std::vector<detected_object> ofxDarknet::yolo(cv::InputArray & in, float threshold, float maxOverlap)
+{
+	cv::Mat mat = in.getMat();
 
-    std::vector< detected_object > detections;
-    int num = l.w*l.h*l.n;
-    
-    int feature_layer = net.n - 2;
-    layer l1 = net.layers[ feature_layer ];
-    float * features = get_network_output_layer_gpu(net, feature_layer);
-    
-    vector<size_t> sorted(num);
-    iota(sorted.begin(), sorted.end(), 0);
-    sort(sorted.begin(), sorted.end(), [&probs, &l](int i1, int i2) {
-        return probs[i1][max_index(probs[i1], l.classes)] > probs[i2][max_index(probs[i2], l.classes)];
-    });
-    
-	for( int i = 0; i < num; ++i ) {
-        int idx = sorted[i];
-		int class1 = max_index( probs[ idx ], l.classes );
-		float prob = probs[ idx ][ class1 ];
+	int originalWidth = mat.cols;
+	int originalHeight = mat.rows;
+	if (mat.cols != net.w && mat.rows != net.h) {
+		cv::resize(mat, mat, cv::Size(net.w, net.h));
+	}
+	image im = convert(mat);
+	
+	return processImage(im, threshold, maxOverlap, originalWidth, originalHeight);
+}
+#endif
 
-        if( prob < threshold ) {
-            continue;
-        }
+std::vector<detected_object> ofxDarknet::processImage(image im, float threshold, float maxOverlap, int originalWidth, int originalHeight)
+{
+	layer l = net.layers[net.n - 1];
 
-        int offset = class1 * 123457 % l.classes;
-        float red = get_color( 2, offset, l.classes );
-        float green = get_color( 1, offset, l.classes );
-        float blue = get_color( 0, offset, l.classes );
+	box *boxes = (box*)calloc(l.w*l.h*l.n, sizeof(box));
+	float **probs = (float**)calloc(l.w*l.h*l.n, sizeof(float *));
+	for (int j = 0; j < l.w*l.h*l.n; ++j) probs[j] = (float*)calloc(l.classes, sizeof(float *));
 
-        box b = boxes[ idx ];
+	network_predict(net, im.data1);
+	get_region_boxes(l, 1, 1, threshold, probs, boxes, 0, 0);
+	do_nms_sort(boxes, probs, l.w*l.h*l.n, l.classes, 0.4);
+	free_image(im);
 
-        int left = ( b.x - b.w / 2. )*im.w;
-        int right = ( b.x + b.w / 2. )*im.w;
-        int top = ( b.y - b.h / 2. )*im.h;
-        int bot = ( b.y + b.h / 2. )*im.h;
+	std::vector< detected_object > detections;
+	int num = l.w*l.h*l.n;
 
-        if( left < 0 ) left = 0;
-        if( right > im.w - 1 ) right = im.w - 1;
-        if( top < 0 ) top = 0;
-        if( bot > im.h - 1 ) bot = im.h - 1;
+	int feature_layer = net.n - 2;
+	layer l1 = net.layers[feature_layer];
+	float * features = get_network_output_layer_gpu(net, feature_layer);
 
-        left = ofMap( left, 0, net.w, 0, originalWidth );
-        top = ofMap( top, 0, net.h, 0, originalHeight );
-        right = ofMap( right, 0, net.w, 0, originalWidth );
-        bot = ofMap( bot, 0, net.h, 0, originalHeight );
+	vector<size_t> sorted(num);
+	iota(sorted.begin(), sorted.end(), 0);
+	sort(sorted.begin(), sorted.end(), [&probs, &l](int i1, int i2) {
+		return probs[i1][max_index(probs[i1], l.classes)] > probs[i2][max_index(probs[i2], l.classes)];
+	});
 
-        ofRectangle rect = ofRectangle( left, top, right - left, bot - top );
-        int rect_idx = floor(idx / l.n);
-        
-        float overlap = 0.0;
-        for (auto d : detections) {
-            float left = max(rect.x, d.rect.x);
-            float right = min(rect.x+rect.width, d.rect.x+d.rect.width);
-            float bottom = min(rect.y+rect.height, d.rect.y+d.rect.height);
-            float top = max(rect.y, d.rect.y);
-            float area_intersection = max(0.0f, right-left) * max(0.0f, bottom-top);
-            overlap = max(overlap, area_intersection / (rect.getWidth() * rect.getHeight()));
-        }
-        if (overlap > maxOverlap) {
-            continue;
-        }
+	for (int i = 0; i < num; ++i) {
+		int idx = sorted[i];
+		int class1 = max_index(probs[idx], l.classes);
+		float prob = probs[idx][class1];
 
-        detected_object detection;
-        detection.label = names[ class1 ];
-        detection.probability = prob;
-        detection.rect = rect;
-        detection.color = ofColor( red * 255, green * 255, blue * 255);
+		if (prob < threshold) {
+			continue;
+		}
 
-        for (int f=0; f<l1.c; f++) {
-            detection.features.push_back(features[rect_idx + l1.w * l1.h * f]);
-        }
-        
-        detections.push_back( detection );
-    }
-    
-    free_ptrs((void**) probs, num);
-    free(boxes);
+		int offset = class1 * 123457 % l.classes;
+		float red = get_color(2, offset, l.classes);
+		float green = get_color(1, offset, l.classes);
+		float blue = get_color(0, offset, l.classes);
+
+		box b = boxes[idx];
+
+		int left = (b.x - b.w / 2.)*im.w;
+		int right = (b.x + b.w / 2.)*im.w;
+		int top = (b.y - b.h / 2.)*im.h;
+		int bot = (b.y + b.h / 2.)*im.h;
+
+		if (left < 0) left = 0;
+		if (right > im.w - 1) right = im.w - 1;
+		if (top < 0) top = 0;
+		if (bot > im.h - 1) bot = im.h - 1;
+
+		left = ofMap(left, 0, net.w, 0, originalWidth);
+		top = ofMap(top, 0, net.h, 0, originalHeight);
+		right = ofMap(right, 0, net.w, 0, originalWidth);
+		bot = ofMap(bot, 0, net.h, 0, originalHeight);
+
+		ofRectangle rect = ofRectangle(left, top, right - left, bot - top);
+		int rect_idx = floor(idx / l.n);
+
+		float overlap = 0.0;
+		for (auto d : detections) {
+			float left = max(rect.x, d.rect.x);
+			float right = min(rect.x + rect.width, d.rect.x + d.rect.width);
+			float bottom = min(rect.y + rect.height, d.rect.y + d.rect.height);
+			float top = max(rect.y, d.rect.y);
+			float area_intersection = max(0.0f, right - left) * max(0.0f, bottom - top);
+			overlap = max(overlap, area_intersection / (rect.getWidth() * rect.getHeight()));
+		}
+		if (overlap > maxOverlap) {
+			continue;
+		}
+
+		detected_object detection;
+		detection.label = names[class1];
+		detection.probability = prob;
+		detection.rect = rect;
+		detection.color = ofColor(red * 255, green * 255, blue * 255);
+
+		for (int f = 0; f<l1.c; f++) {
+			detection.features.push_back(features[rect_idx + l1.w * l1.h * f]);
+		}
+
+		detections.push_back(detection);
+	}
+
+	free_ptrs((void**)probs, num);
+	free(boxes);
 
 	return detections;
 }
@@ -426,4 +449,25 @@ ofPixels ofxDarknet::convert( image & im )
 	ofPixels pix;
 	pix.setFromPixels( data, im.w, im.h, im.c );
 	return pix;
+}
+
+image ofxDarknet::convert(cv::Mat& in)
+{
+	unsigned char *data = (unsigned char *)in.data;
+	int h = in.rows;
+	int w = in.cols;
+	int c = in.channels();
+	int step = w * c;
+	image im = make_image(w, h, c);
+	int i, j, k, count = 0;;
+
+	for (k = 0; k < c; ++k) {
+		for (i = 0; i < h; ++i) {
+			for (j = 0; j < w; ++j) {
+				im.data1[count++] = data[i*step + j*c + k] / 255.;
+			}
+		}
+	}
+
+	return im;
 }

--- a/src/ofxDarknet.cpp
+++ b/src/ofxDarknet.cpp
@@ -451,6 +451,7 @@ ofPixels ofxDarknet::convert( image & im )
 	return pix;
 }
 
+#ifdef OPENCV
 image ofxDarknet::convert(cv::Mat& in)
 {
 	unsigned char *data = (unsigned char *)in.data;
@@ -471,3 +472,4 @@ image ofxDarknet::convert(cv::Mat& in)
 
 	return im;
 }
+#endif

--- a/src/ofxDarknet.h
+++ b/src/ofxDarknet.h
@@ -37,9 +37,8 @@
 #include "nightmare.h"
 #include "rnn.h"
 
-//#include "ofxOpenCv.h"
-
 #ifdef OPENCV
+#include <opencv2/opencv.hpp>
 #include "opencv2/highgui/highgui_c.h"
 #endif
 
@@ -78,6 +77,9 @@ public:
     
     std::vector< classification > classify( ofPixels & pix, int count = 5 );
     std::vector< detected_object > yolo( ofPixels & pix, float threshold = 0.24f, float maxOverlap = 0.5f );
+	#ifdef OPENCV
+	std::vector< detected_object > yolo(cv::InputArray & in, float threshold = 0.24f, float maxOverlap = 0.5f);
+	#endif
     std::vector< activations > getFeatureMaps(int idxLayer);
 
     ofImage nightmare( ofPixels & pix, int max_layer, int range, int norm, int rounds, int iters, int octaves, float rate, float thresh );
@@ -90,6 +92,10 @@ public:
 protected:
     image convert( ofPixels & pix );
     ofPixels convert( image & image );
+
+	#ifdef OPENCV
+	image convert(cv::Mat& in);
+	#endif
     
 	list1 *options1;
 	char **names;
@@ -97,6 +103,8 @@ protected:
 	network net;
     bool loaded;
     bool labelsAvailable;
+
+	std::vector< detected_object > processImage(image im, float threshold, float maxOverlap, int originalWidth, int originalHeight);
 };
 
 

--- a/src/ofxDarknet.h
+++ b/src/ofxDarknet.h
@@ -37,7 +37,7 @@
 #include "nightmare.h"
 #include "rnn.h"
 
-#include "ofxOpenCv.h"
+//#include "ofxOpenCv.h"
 
 #ifdef OPENCV
 #include "opencv2/highgui/highgui_c.h"


### PR DESCRIPTION
Hello! This is my first pull request, so please bear with me if I messed something up.

I made some changes to support using ofxDarknet directly with opencv Mat objects. If OPENCV is defined, these can be used, otherwise the user can fall back on the methods that take ofImages. 

I didn't see the need for ofxOpenCV to be in there, so I took it out -- does it actually get used if you don't have OPENCV defined?

Thanks!